### PR TITLE
Remove dependency on once_cell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,8 @@ version = "0.1.1"
 
 [dependencies]
 plotters = { version = "^0.3", optional = true }
-once_cell = { version = "^1.8", optional = true }
 num-traits = { version = "^0.2", optional = true }
 
 [features]
 default = ["debug"]
-debug = ["plotters", "once_cell", "num-traits"]
+debug = ["plotters", "num-traits"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,18 +24,17 @@ macro_rules! plot {
         #[cfg(debug_assertions)]
         #[cfg(feature = "debug")]
         {
-            use once_cell::unsync::Lazy;
             use std::cell::RefCell;
             use $crate::Plottable;
 
             thread_local! {
-                static PLOT: Lazy<RefCell<$crate::Plot>> = Lazy::new(|| {
+                static PLOT: RefCell<$crate::Plot> = {
                     let mut name: Option<String> = None;
                     $(
                         name = Some(format!("{}", $name));
                     )?
                     RefCell::new($crate::Plot::new([$(stringify!($variable)),*], (file!(), line!()), name))
-                });
+                };
             }
             PLOT.with(|plot| {
                 plot.borrow_mut().insert([$($variable.to_plot_type()),*]);


### PR DESCRIPTION
I think `once_cell::Lazy` is not necessary, since `thread_local!` content is already supposed to be initialized lazily.[^1]

[^1]: https://doc.rust-lang.org/std/thread/struct.LocalKey.html#initialization-and-destruction