### PR TITLE
Add missing conditional compiler macros

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,6 +134,7 @@ pub use debug::*;
 
 mod debug {
     use num_traits::cast::ToPrimitive;
+    #[cfg(feature = "live")]
     use piston_window::EventLoop;
     #[cfg(feature = "live")]
     use piston_window::{PistonWindow, WindowSettings};
@@ -226,7 +227,11 @@ mod debug {
                 ..options
             };
 
+
+            #[cfg(feature = "live")]
             let live = options.live.unwrap_or(false);
+            #[cfg(not(feature = "live"))]
+                let live = false;
 
             PlotWrapper {
                 live,


### PR DESCRIPTION
Since the piston dependency is now out of date I had to disable it via `default_features = false` for now in my `Cargo.toml` but ran into some errors due to conditionally compiling without it. Here are the missing macros. Note that someone should update the piston backend code so that the `live` feature works again.